### PR TITLE
tools/dustElfToBin: Bug fix related to Windows file path and process operation

### DIFF
--- a/tools/dustElfToBin/dustElfToBin.py
+++ b/tools/dustElfToBin/dustElfToBin.py
@@ -93,21 +93,27 @@ def write_checksum_length_into_file (binFile, elfFile):
 def elf_to_bin (binName, elfName):
    status = 0
    output = ''
-   toolVer = "6.40.1"
    try:
-      toolBase = os.environ['IAR_ARM_BASE']
+       toolBase = os.environ['IAR_ARM_BASE']
    except KeyError:
-      toolBase = os.path.join ('/Program Files','IAR Systems', 'EW_ARM_'+toolVer) # default
+       print >> sys.stderr, "Error: Environment variable IAR_ARM_BASE was not found.\
+       \nTry to set IAR_ARM_BASE to the top directry of EWARM.\
+       \n(e.g. C:\\Program Files (x86)\\IAR Systems\\Embedded Workbench 8.0 )"
+       raise
    
    elfToBin = os.path.join(toolBase, 'arm','bin','ielftool.exe')
-   execCmd = [elfToBin,'--bin', '--verbose', elfName, binName]
+   execCmd = [elfToBin, '--bin', '--verbose', elfName, binName]
    if os.name in ['nt', 'win32']:
-      p = Popen(execCmd, shell=False, stdin=None, stdout=PIPE, stderr=STDOUT)
+      p = Popen(execCmd, shell=True, stdin=None, stdout=PIPE, stderr=STDOUT)
    else:
       # shell=False means python will handle the quoting for us
       p = Popen(execCmd, shell=False, stdin=None, stdout=PIPE, stderr=STDOUT, close_fds=True)
    output = p.communicate()[0]
    status = p.returncode
+   if status:
+       print >> sys.stderr, "Error ielftool.exe returned non-zero exit status ", status 
+       print output
+       exit(1)
    return status, output
 
 # main program


### PR DESCRIPTION
I found the python script (tools/dustElfToBin/dustElfToBin.py) failed on Windows due to three reasons.

1. File path encoding
Original code use a hard-coded location when an environment variable (`IAR_ARM_BASE`) is not found.
However, this treatment should be avoided because the IAR location is much varied depending on version, user's configuration, etc.
Therefore I fixed this code to just raising exception when `IAR_ARM_BASE `is not found.

2. UAC 
On Windows 7 or later, sometimes executing ielftool.exe is failed due to privilege issue (Popen returned `WindowsError: [Error 5] Access is denied`). 
To avoid this error, `shell` should be set to `True`.

3. ielftool.exe error
Although ielftool.exe returns error, the script continued running.
To handle error case, I changed the script to be terminated when ielftool returns non-zero status.
